### PR TITLE
Sort out issue with init_db()

### DIFF
--- a/progress.py
+++ b/progress.py
@@ -19,7 +19,13 @@ def init_db():
 
 @app.before_request
 def before_request():
-    g.db = connect_db()
+#try to connect to the database. 
+#if it hasn't been initialized, do that
+    try:
+        g.db = connect_db()
+    except sqlite3.OperationalError:
+        g.db = connect_db()
+        init_db()
 
 @app.teardown_request
 def teardown_request(exception):


### PR DESCRIPTION
If you add a error catch to the before_request function, you can make sure that the database is always initialized before running a cursor.